### PR TITLE
设置当前账号的变量，获取资源的时候，需要传递当前账号。

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -48,6 +48,9 @@ export const App = () => {
   // 已连接账户
   const [account, setAccount] = useState([]);
 
+  // 设置当前激活的账户
+  const [activeAccount, setActiveAccount] = useState("");
+
   const [isInstall, setInstall] = useState(true);
 
   const freshConnected = useCallback(async () => {
@@ -56,6 +59,7 @@ export const App = () => {
     });
     setAccount([...newAccounts]);
     setConnected(newAccounts && newAccounts.length > 0);
+    setActiveAccount(newAccounts.length > 0 ? newAccounts[0] : "");
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION

很多 demo 获取资源里传递是部署合约的账号。
需要传递当前调用者的账号。 

所以设置一个当前账号的变量，获取资源的时候，传递这个变量。